### PR TITLE
Snipe While Train MOD

### DIFF
--- a/CGB Bot.au3
+++ b/CGB Bot.au3
@@ -115,21 +115,21 @@ Func runBot() ;Bot that runs everything in order
 			Endif
 			Laboratory()
 			    	If _Sleep(1000) Then Return
-			    
+
 			    checkMainScreen(False)
 			UpgradeWall()
 				If _Sleep(1000) Then Return
-				
+
 			    checkMainScreen(False)
 			;Mow the lawn
 			RemoveTrees()
 				If _Sleep(1000) Then Return
-				
+
 			    checkMainScreen(False)
 			;End Mow the lawn
 			UpgradeHeroes()
 				If _Sleep(1000) Then Return
-				
+
 			    checkMainScreen(False)
 			UpgradeBuilding()
 				If _Sleep(1000) Then Return
@@ -162,7 +162,7 @@ Func Idle() ;Sequence that runs until Full Army
 		While $iReHere < 10
 			$iReHere += 1
 			DonateCC(true)
-			If _Sleep(3000) Then ExitLoop
+			If _Sleep(1500) Then ExitLoop
 		WEnd
 		If _Sleep(1500) Then ExitLoop
 
@@ -196,6 +196,10 @@ Func Idle() ;Sequence that runs until Full Army
 			    checkMainScreen(False)
 		EndIf
 
+		 If($iChkSnipeWhileTrain) Then
+			SnipeWhileTrain() ;; Initiate at the end of Idle() loop ; Snipe While Train MOD by ChiefM3
+		 EndIf
+
 		$TimeIdle += Round(TimerDiff($hTimer) / 1000, 2) ;In Seconds
 		SetLog("Time Idle: " & StringFormat("%02i", Floor(Floor($TimeIdle / 60) / 60)) & ":" & StringFormat("%02i", Floor(Mod(Floor($TimeIdle / 60), 60))) & ":" & StringFormat("%02i", Floor(Mod($TimeIdle, 60))), $COLOR_GREEN)
 	WEnd
@@ -210,6 +214,7 @@ Func AttackMain() ;Main control for attack functions
 
 	PrepareSearch()
 	VillageSearch()
+	If $haltSearch = True Then Return ; Return without initiating attack for Snipe While Train MOD by ChiefM3
 	PrepareAttack()
 	;checkDarkElix()
 	DEAttack()

--- a/COCBot/CGB Functions.au3
+++ b/COCBot/CGB Functions.au3
@@ -28,6 +28,7 @@
 #include "functions\Attack\ReturnHome.au3"
 #include "functions\Attack\SetSleep.au3"
 #include "functions\Attack\Unbreakable.au3"
+#include "functions\Attack\SnipeWhileTrain.au3"
 #include "functions\Attack\Attack Algorithms\algorithm_AllTroops.au3"
 #include "functions\Attack\Attack Algorithms\algorithm_Barch.au3"
 #include "functions\Attack\Attack Algorithms\algorithmTH.au3"

--- a/COCBot/CGB GUI Design.au3
+++ b/COCBot/CGB GUI Design.au3
@@ -546,6 +546,8 @@ GUICtrlCreateTabItem("")
 		$y +=22
 		$chkAttackTH = GUICtrlCreateCheckbox("Attack Townhall Outside", $x, $y, -1, -1)
 			GUICtrlSetTip(-1, "Check this to Attack an exposed Townhall first. (Townhall outside of Walls)" & @CRLF & "TIP: Also tick 'Meet Townhall Outside' on the Search tab if you only want to search for bases with exposed Townhalls.")
+	    $chkSnipeWhileTrain = GUICtrlCreateCheckbox("TH snipe while training army", $x + 200, $y, -1, -1) ; Snipe While Train MOD by ChiefM3
+			GUICtrlSetTip(-1, "Bot will try to TH snipe while training army.")
 		$y +=22
 		$chkLightSpell = GUICtrlCreateCheckbox("Hit Dark Elixir storage with Lightning Spell", $x, $y, -1, -1)
 			GUICtrlSetTip(-1, "Check this if you want to use lightning spells to steal Dark Elixir when bot meet Minimum Dark Elixir.")
@@ -829,7 +831,7 @@ $y += 40
 		GUICtrlSetImage (-1, $LibDir & "\CGBBOT.dll", 35, 1)
 		GUICtrlSetOnEvent(-1, "btnDonateLavaHounds")
 		;GUICtrlSetState (-1, $GUI_DISABLE)
-		
+
 	;;; Custom Combination Donate by ChiefM3
 	$lblBtnCustom = GUICtrlCreateLabel("", $x + 263, $y - 2, 42, 42)
 		GUICtrlSetBkColor(-1, $GUI_BKCOLOR_TRANSPARENT)
@@ -1333,7 +1335,7 @@ $y += 75
 			GUICtrlSetData(-1, StringFormat("no\r\ncw\r\nwar"))
 			GUICtrlSetTip(-1, "Blacklist for donating Custom Troops")
 	GUICtrlCreateGroup("", -99, -99, 1, 1)
-	
+
 	$grpBlacklist = GUICtrlCreateGroup("General Blacklist", $x - 20, $y - 20, 450, 190)
 		GUICtrlSetState(-1, $GUI_HIDE)
 		$picDonateBlacklist = GUICtrlCreateIcon ($LibDir & "\CGBBOT.dll", 63, $x + 215, $y, 64, 64, $BS_ICON)
@@ -1622,7 +1624,7 @@ $tabMisc = GUICtrlCreateTabItem("Misc")
 			$txtTip = "Attack a Deadbase found on the first search while dropping Trophies."
 			GUICtrlSetTip(-1, $txtTip)
 	GUICtrlCreateGroup("", -99, -99, 1, 1)
-	
+
 	Local $x = 260, $y = 275
 	$grpLocateBuildings = GUICtrlCreateGroup("Locate Manually", $x - 20, $y - 20, 220, 65)
 		$btnLocateTownHall = GUICtrlCreateButton("Townhall", $x - 10, $y, 40, 40, $BS_ICON)
@@ -1704,7 +1706,7 @@ Local $x = 30, $y = 125
 			GUICtrlSetLimit(-1, 7)
 			GUICtrlSetState(-1, $GUI_DISABLE)
 	GUICtrlCreateGroup("", -99, -99, 1, 1)
-	
+
 	$y += 115
 	$grpUpgrades = GUICtrlCreateGroup("Upgrades Queue", $x - 20, $y - 20, 220, 110)
 	$chkUpgrade1 = GUICtrlCreateCheckbox("Upgrade 1", $x-10, $y - 3, -1, 20)
@@ -1761,7 +1763,7 @@ Local $x = 30, $y = 125
 		$txtBuilderKeepFree = GUICtrlCreateInput("0", $x + 100, $y + 57, 61, 21, BitOR($GUI_SS_DEFAULT_INPUT, $ES_CENTER, $ES_NUMBER))
 			GUICtrlSetTip(-1, "Keep free builders to build walls or otherwise.")
 			GUICtrlSetLimit(-1, 1)
-		
+
 		$x -= 230
 		$y += 105
 		$Laboratory = GUICtrlCreateGroup("Laboratory", $x - 20, $y - 20, 500, 70)
@@ -1892,7 +1894,7 @@ Local $x = 30, $y = 125
 		GUICtrlSetImage (-1, $LibDir & "\CGBBOT.dll", 35, 1)
 		GUICtrlSetOnEvent(-1, "btnTroopsLavaHounds")
 		;GUICtrlSetState (-1, $GUI_DISABLE)
-	
+
 		$x += 2
 		$y += 70
         $grpLocateBuildings = GUICtrlCreateGroup("Locate Heroes", $x - 20, $y - 20, 220, 65)
@@ -2029,7 +2031,7 @@ Local $x = 30, $y = 130
 			$txtTip = "The amount of Trophies you gained or lost on the last attack."
 			GUICtrlSetTip(-1, $txtTip)
 	GUICtrlCreateGroup("", -99, -99, 1, 1)
-	
+
 	$x += 113
 	$y = 130
     $grpTotalLoot = GUICtrlCreateGroup("Stats: Total Loot", $x - 20, $y - 20, 108, 105)

--- a/COCBot/CGB Global Variables.au3
+++ b/COCBot/CGB Global Variables.au3
@@ -192,6 +192,7 @@ Global $iradAttackMode ;Attack mode, 0 1 2
 Global $iradAttackModeString
 Global $THLoc
 Global $chkATH, $iChkLightSpell
+Global $iChkSnipeWhileTrain, $isSnipeWhileTrain, $tempSnipeWhileTrain[14], $haltSearch ; Snipe While Train MOD by ChiefM3
 
 Global $King, $Queen, $CC, $Barb, $Arch, $LSpell , $LSpellQ
 Global $LeftTHx, $RightTHx, $BottomTHy, $TopTHy

--- a/COCBot/functions/Attack/SnipeWhileTrain.au3
+++ b/COCBot/functions/Attack/SnipeWhileTrain.au3
@@ -1,0 +1,98 @@
+; #FUNCTION# ====================================================================================================================
+; Name ..........: SnipeWhileTrain
+; Description ...: During the idle loop, if $chkSnipeWhileTrain is checked, the bot will to for only TH snipe and return after
+;                  10 searches to profit from idle time.
+;                  VillageSearch() was modified to break search after 10 loops.
+;                  GetResources() was modified to turn of SnipeWhileTrain when OoS occurs
+;                  4 global variables are used for this function.
+;                  Global $chkSnipeWhileTrain, $isSnipeWhileTrain, $tempSnipeWHileTrain[14], $haltSearch
+; Syntax ........: SnipeWhileTrain(), TurnOnSnipeWhileTrain(), TurnOffSnipeWhileTrain()
+; Parameters ....: None
+; Return values .: False if not enough (<30%) troops, True if 10 searches was successfully done.
+; Author ........: ChiefM3 (May 2015)
+; Modified ......:
+; Remarks .......: This file is part of ClashGameBot. Copyright 2015
+;                  ClashGameBot is distributed under the terms of the GNU GPL
+; Related .......:
+; Link ..........:
+; Example .......:
+; ===============================================================================================================================
+
+Func SnipeWhileTrain()
+   ; Attempt only when 30% army full to prevent failure of TH snipe
+   If $TotalCamp * $fulltroop < 0.3 Then
+	  Return False
+   EndIf
+
+   TurnOnSnipeWhileTrain()
+
+   AttackMain()
+
+   TurnOffSnipeWhileTrain()
+
+   Return True
+
+EndFunc
+
+Func TurnOnSnipeWhileTrain()
+   SetLog("[[[Start trying TH snipe while training army]]]", $COLOR_GREEN)
+   ; Swap variables to pure TH snipe mode
+   $tempSnipeWhileTrain[0] = $iradAttackMode ; attack mode
+   $tempSnipeWhileTrain[1] = $chkConditions[0]
+   $tempSnipeWhileTrain[2] = $chkConditions[1]
+   $tempSnipeWhileTrain[3] = $chkConditions[2]
+   $tempSnipeWhileTrain[4] = $chkConditions[3]
+   $tempSnipeWhileTrain[5] = $chkConditions[4]
+   $tempSnipeWhileTrain[6] = $chkConditions[5]
+   $tempSnipeWhileTrain[7] = $chkConditions[6]
+   $tempSnipeWhileTrain[8] = $MinGold
+   $tempSnipeWHileTrain[9] = $MinElixir
+   $tempSnipeWhileTrain[10] = $ichkMeetOne ; search meet one
+   $tempSnipeWhileTrain[11] = $chkATH ; Attack Town Hall
+   $tempSnipeWhileTrain[12] = $OptTrophyMode ; TH snipe
+   $tempSnipeWhileTrain[13] = $THaddtiles ; Th snipe tiles
+   $iradAttackMode = 2
+   $chkConditions[0] = 0
+   $chkConditions[1] = 0
+   $chkConditions[2] = 0
+   $chkConditions[3] = 1
+   $chkConditions[4] = 0
+   $chkConditions[5] = 1
+   $chkConditions[6] = 0
+   $MinGold = 1
+   $MinElixir = 1
+   $ichkMeetOne = 0
+   $chkATH = 1
+   $OptTrophyMode = 1
+   If $TotalCamp * $fulltroop < 0.6 Then
+	  $THaddtiles = 0 ;; Safe TH snipe if army under 60%
+   Else
+	  $THaddtiles = 1 ;; Take a bit of risk if army over 60%
+   EndIf
+
+   ; go to search for 10 times
+   $isSnipeWhileTrain = True ; Lets the SearchVillage() function to know this is a part of Snipe While Train MOD
+EndFunc
+
+Func TurnOffSnipeWhileTrain()
+   $haltSearch = False ; VillageSearch() sets $haltSearch as True to end search after 10 attempts, so put it back to False
+   $Is_ClientSyncError = False ; In case 10 searches ends with an OoS
+   $isSnipeWhileTrain = False ; Put it back to normal search mode
+
+   ; revert settings back to normal
+   $iradAttackMode = $tempSnipeWhileTrain[0]
+   $chkConditions[0] = $tempSnipeWhileTrain[1]
+   $chkConditions[1] = $tempSnipeWhileTrain[2]
+   $chkConditions[2] = $tempSnipeWhileTrain[3]
+   $chkConditions[3] = $tempSnipeWhileTrain[4]
+   $chkConditions[4] = $tempSnipeWhileTrain[5]
+   $chkConditions[5] = $tempSnipeWhileTrain[6]
+   $chkConditions[6] = $tempSnipeWhileTrain[7]
+   $MinGold = $tempSnipeWhileTrain[8]
+   $MinElixir = $tempSnipeWhileTrain[9]
+   $ichkMeetOne = $tempSnipeWhileTrain[10]
+   $chkATH = $tempSnipeWhileTrain[11]
+   $OptTrophyMode = $tempSnipeWhileTrain[12]
+   $THaddtiles = $tempSnipeWhileTrain[13]
+   SetLog("[[[End trying TH snipe while training army]]]", $COLOR_RED)
+EndFunc

--- a/COCBot/functions/Config/applyConfig.au3
+++ b/COCBot/functions/Config/applyConfig.au3
@@ -210,8 +210,8 @@ Func applyConfig() ;Applies the data from config to the controls in GUI
 
 	GUICtrlSetData($txtRatioNumeratorDonated, $ratioNumeratorDonated)
 	GUICtrlSetData($txtRatioDenominatorReceived, $ratioDenominatorReceived)
-	
-	
+
+
 	Switch $iActivateKQCondition
 		Case "Manual"
 			GUICtrlSetState($radManAbilities, $GUI_CHECKED)
@@ -249,9 +249,15 @@ Func applyConfig() ;Applies the data from config to the controls in GUI
 		GUICtrlSetState($chkAttackTH, $GUI_CHECKED)
 	Else
 		GUICtrlSetState($chkAttackTH, $GUI_UNCHECKED)
+    EndIf
+
+    If $iChkSnipeWhileTrain = 1 Then ; Snipe While Train MOD by ChiefM3
+		GUICtrlSetState($chkSnipeWhileTrain, $GUI_CHECKED)
+	Else
+		GUICtrlSetState($chkSnipeWhileTrain, $GUI_UNCHECKED)
 	EndIf
 
-	If $iChkLightSpell = 1 Then
+    If $iChkLightSpell = 1 Then
 		GUICtrlSetState($chkLightSpell, $GUI_CHECKED)
 	Else
 		GUICtrlSetState($chkLightSpell, $GUI_UNCHECKED)
@@ -450,7 +456,7 @@ Func applyConfig() ;Applies the data from config to the controls in GUI
 	chkDonateLavaHounds()
 	GUICtrlSetData($txtDonateLavaHounds, $sTxtDonateLavaHounds)
 	GUICtrlSetData($txtBlacklistLavaHounds, $sTxtBlacklistLavaHounds)
-	
+
 	;;; Custom Combination Donate by ChiefM3
 	If $ichkDonateCustom = 1 Then
 		GUICtrlSetState($chkDonateCustom, $GUI_CHECKED)
@@ -466,7 +472,7 @@ Func applyConfig() ;Applies the data from config to the controls in GUI
 	GUICtrlSetData($txtDonateCustom2, $itxtDonateCustom2)
 	_GUICtrlComboBox_SetCurSel($cmbDonateCustom3, $icmbDonateCustom3)
 	GUICtrlSetData($txtDonateCustom3, $itxtDonateCustom3)
-	
+
 	GUICtrlSetData($txtBlacklist, $sTxtBlacklist)
 
 	If $ichkDonateAllBarbarians = 1 Then
@@ -748,13 +754,13 @@ Func applyConfig() ;Applies the data from config to the controls in GUI
     GUICtrlSetData($txtBuildMinElixir, $itxtBuildMinElixir)
     GUICtrlSetData($txtBuildMinDark, $itxtBuildMinDark)
     GUICtrlSetData($txtBuilderKeepFree, $itxtBuilderKeepFree)
-	
+
 	If $ichkUpgradeKing = 1 Then ;==>upgradeking
 		GUICtrlSetState($chkUpgradeKing, $GUI_CHECKED)
 	Else
 		GUICtrlSetState($chkUpgradeKing, $GUI_UNCHECKED)
 	EndIf
-	
+
 	If $ichkUpgradeQueen = 1 Then ;==>upgradequeen
 		GUICtrlSetState($chkUpgradeQueen, $GUI_CHECKED)
 	Else

--- a/COCBot/functions/Config/readConfig.au3
+++ b/COCBot/functions/Config/readConfig.au3
@@ -16,7 +16,7 @@ Func readConfig() ;Reads config and sets it to the variables
 
 		$SFPos[0] = IniRead($building, "other", "xspellfactory", "-1")
 		$SFPos[1] = IniRead($building, "other", "yspellfactory", "-1")
-		
+
 		$KingPos[0] = IniRead($building, "other", "xKing", "0")
 		$KingPos[1] = IniRead($building, "other", "yKing", "0")
 		$QueenPos[0] = IniRead($building, "other", "xQueen", "0")
@@ -126,6 +126,7 @@ Func readConfig() ;Reads config and sets it to the variables
 		$iAttackNowDelay = IniRead($config, "advanced", "attacknowdelay", "3")
 
 		$chkATH = IniRead($config, "advanced", "townhall", "0")
+		$iChkSnipeWhileTrain = IniRead($config, "advanced", "chkSnipeWhileTrain", "0") ; Snipe While Train MOD by ChiefM3
 		$iChkLightSpell = IniRead($config, "advanced", "hitDElightning", "0")
 		$SpellMinDarkStorage = IniRead($config, "advanced", "txtMinDarkStorage", "500")
         $iLSpellQ = IniRead ($config, "advanced", "QLSpell", "3")
@@ -278,7 +279,7 @@ Func readConfig() ;Reads config and sets it to the variables
 		$itxtDonateCustom2 = IniRead($config, "donate", "txtDonateCustom2", "0")
 		$icmbDonateCustom3 = IniRead($config, "donate", "cmbDonateCustom3", "0")
 		$itxtDonateCustom3 = IniRead($config, "donate", "txtDonateCustom3", "0")
-		
+
 		$sTxtBlacklist = StringReplace(IniRead($config, "donate", "txtBlacklist", "clan war|war|cw"), "|", @CRLF)
 		$aBlackList = StringSplit($sTxtBlackList, @CRLF, $STR_ENTIRESPLIT)
 
@@ -308,7 +309,7 @@ Func readConfig() ;Reads config and sets it to the variables
         $itxtBuildMinElixir = IniRead($config, "other", "minbuildelixir", "0")
         $itxtBuildMinDark = IniRead($config, "other", "minbuildark", "0")
         $itxtBuilderKeepFree = IniRead($config, "other", "builderkeepfree", "0")
-		
+
 		$ichkUpgradeKing = IniRead($config, "other", "UpKing", "0") ;==>upgradeking
 		$ichkUpgradeQueen = IniRead($config, "other", "UpQueen", "0") ;==>upgradequeen
 

--- a/COCBot/functions/Config/saveConfig.au3
+++ b/COCBot/functions/Config/saveConfig.au3
@@ -234,6 +234,12 @@ Func saveConfig() ;Saves the controls settings to the config
 		IniWrite($config, "advanced", "townhall", 0)
 	EndIf
 
+    If GUICtrlRead($chkSnipeWhileTrain) = $GUI_CHECKED Then ; Snipe While Train MOD by ChiefM3
+	   IniWrite($config, "advanced", "chkSnipeWhileTrain", 1)
+    Else
+	   IniWrite($config, "advanced", "chkSnipeWhileTrain", 0)
+    EndIf
+
 	If GUICtrlRead($chkLightSpell) = $GUI_CHECKED Then
 		IniWrite($config, "advanced", "hitDElightning", 1)
 	Else
@@ -528,7 +534,7 @@ Func saveConfig() ;Saves the controls settings to the config
 
 	IniWrite($config, "donate", "txtDonateLavaHounds", StringReplace(GUICtrlRead($txtDonateLavaHounds), @CRLF, "|"))
 	IniWrite($config, "donate", "txtBlacklistLavaHounds", StringReplace(GUICtrlRead($txtBlacklistLavaHounds), @CRLF, "|"))
-	
+
 	;;; Custom Combination Donate by ChiefM3
 	If GUICtrlRead($chkDonateCustom) = $GUI_CHECKED Then
 		IniWrite($config, "donate", "chkDonateCustom", 1)
@@ -541,7 +547,7 @@ Func saveConfig() ;Saves the controls settings to the config
 		IniWrite($config, "donate", "chkDonateAllCustom", 0)
 	EndIf
 	IniWrite($config, "donate", "txtDonateCustom", StringReplace(GUICtrlRead($txtDonateCustom), @CRLF, "|"))
-	
+
     IniWrite($config, "donate", "txtBlacklistCustom", StringReplace(GUICtrlRead($txtBlacklistCustom), @CRLF, "|"))
 
    IniWrite($config, "donate", "cmbDonateCustom1", _GUICtrlComboBox_GetCurSel($cmbDonateCustom1))
@@ -671,13 +677,13 @@ If GUICtrlRead($chkLab) = $GUI_CHECKED Then
 	IniWrite($building, "other", "BuildUpgradeY3", GUICtrlRead($txtUpgradeY3))
 	IniWrite($building, "other", "BuildUpgradeX4", GUICtrlRead($txtUpgradeX4))
 	IniWrite($building, "other", "BuildUpgradeY4", GUICtrlRead($txtUpgradeY4))
-	
+
 	If GUICtrlRead($chkUpgradeKing) = $GUI_CHECKED Then ;==>upgradeking
 		IniWrite($config, "other", "UpKing", 1)
 	Else
 		IniWrite($config, "other", "UpKing", 0)
 	EndIf
-	
+
 	If GUICtrlRead($chkUpgradeQueen) = $GUI_CHECKED Then ;==>upgradequeen
 		IniWrite($config, "other", "UpQueen", 1)
 	Else

--- a/COCBot/functions/Search/GetResources.au3
+++ b/COCBot/functions/Search/GetResources.au3
@@ -21,6 +21,9 @@ Func GetResources() ;Reads resources
 			$Is_ClientSyncError = True
 			GUICtrlSetData($lblresultoutofsync, GUICtrlRead($lblresultoutofsync)+ 1)
 			$iStuck = 0
+			If $isSnipeWhileTrain Then ; When OoS occured during Snipe While Train MOD no need to go to search
+			   TurnOffSnipeWhileTrain()
+			EndIf
 			checkMainScreen()
 			Return
 		EndIf
@@ -40,6 +43,9 @@ Func GetResources() ;Reads resources
 		$Is_ClientSyncError = True
 		GUICtrlSetData($lblresultoutofsync, GUICtrlRead($lblresultoutofsync)+ 1)
 		$iStuck = 0
+		If $isSnipeWhileTrain Then ; When OoS occured during Snipe While Train MOD no need to go to search
+		  TurnOffSnipeWhileTrain()
+		EndIf
 		checkMainScreen()
 		Return
 	EndIf

--- a/COCBot/functions/Search/VillageSearch.au3
+++ b/COCBot/functions/Search/VillageSearch.au3
@@ -2,6 +2,7 @@
 
 Func VillageSearch() ;Control for searching a village that meets conditions
 	$iSkipped = 0
+	$haltSearch = False ; to halt searches after 10 attempts ; Snipe While Train Mod by ChiefM3
 
 	If $Is_ClientSyncError = False Then
 		$AimGold = $MinGold
@@ -169,6 +170,12 @@ Func VillageSearch() ;Control for searching a village that meets conditions
 				SetLog(_PadStringCenter(" TH Outside Found! ", 50, "~"), $COLOR_GREEN)
 				ExitLoop
 			Else
+			   ; break every 10 searches when Snipe While Train MOD is activated
+			   If $isSnipeWhileTrain And $iSkipped > 8 Then
+				  Click(62, 519) ; Click End Battle to return home
+				  $haltSearch = True ; To Prevent Initiation of Attack
+				  ExitLoop
+			   EndIf
 				;If _Sleep(1000) Then Return
 				If $bBtnAttackNowPressed = True Then ExitLoop
 				Click(750, 500) ;Click Next


### PR DESCRIPTION
Bot will to for 10 searches of TH outside bases on the end of every
Idle() loop.
Settings are switched to "Meet gold or elixir, Gold=1, Elixir=1,
Townhall outside, 0 or 1 tiles" and then initiates TH snipe attack.
After attack or after 10 searches the settings are switched back to the
users settings.
MOD includes New "COCBot\functions\Attack\SnipeWhileTrain.au3" file
